### PR TITLE
Changes 'dencrypt' to 'decrypt' in comments

### DIFF
--- a/samples/decrypt.js
+++ b/samples/decrypt.js
@@ -43,10 +43,10 @@ async function decrypt(
   );
   const ciphertext = contentsBuffer.toString('base64');
 
-  // Dencrypts the file using the specified crypto key
+  // Decrypts the file using the specified crypto key
   const [result] = await client.decrypt({name, ciphertext});
 
-  // Writes the dencrypted file to disk
+  // Writes the decrypted file to disk
   const writeFile = promisify(fs.writeFile);
   await writeFile(plaintextFileName, Buffer.from(result.plaintext, 'base64'));
   console.log(


### PR DESCRIPTION
Occurs in 2 places

I updated the old repo earlier, looping back to fix this repo too.

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
