### PR TITLE
feat: deferred client initialization

### DIFF
--- a/synth.metadata
+++ b/synth.metadata
@@ -1,12 +1,13 @@
 {
-  "updateTime": "2020-03-04T23:33:59.146435Z",
+  "updateTime": "2020-03-05T23:10:16.979486Z",
   "sources": [
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "dcc5d00fc8a8d8b56f16194d7c682027b2c66a3b",
-        "internalRef": "298953301"
+        "sha": "f0b581b5bdf803e45201ecdb3688b60e381628a8",
+        "internalRef": "299181282",
+        "log": "f0b581b5bdf803e45201ecdb3688b60e381628a8\nfix: recommendationengine/v1beta1 update some comments\n\nPiperOrigin-RevId: 299181282\n\n10e9a0a833dc85ff8f05b2c67ebe5ac785fe04ff\nbuild: add generated BUILD file for Routes Preferred API\n\nPiperOrigin-RevId: 299164808\n\n86738c956a8238d7c77f729be78b0ed887a6c913\npublish v1p1beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299152383\n\n73d9f2ad4591de45c2e1f352bc99d70cbd2a6d95\npublish v1: update with absolute address in comments\n\nPiperOrigin-RevId: 299147194\n\nd2158f24cb77b0b0ccfe68af784c6a628705e3c6\npublish v1beta2: update with absolute address in comments\n\nPiperOrigin-RevId: 299147086\n\n7fca61292c11b4cd5b352cee1a50bf88819dd63b\npublish v1p2beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146903\n\n583b7321624736e2c490e328f4b1957335779295\npublish v1p3beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146674\n\n638253bf86d1ce1c314108a089b7351440c2f0bf\nfix: add java_multiple_files option for automl text_sentiment.proto\n\nPiperOrigin-RevId: 298971070\n\n373d655703bf914fb8b0b1cc4071d772bac0e0d1\nUpdate Recs AI Beta public bazel file\n\nPiperOrigin-RevId: 298961623\n\n"
       }
     },
     {

--- a/test/gapic-key_management_service-v1.ts
+++ b/test/gapic-key_management_service-v1.ts
@@ -85,6 +85,26 @@ describe('v1.KeyManagementServiceClient', () => {
     );
     assert(client);
   });
+  it('has initialize method and supports deferred initialization', async () => {
+    const client = new keymanagementserviceModule.v1.KeyManagementServiceClient(
+      {
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      }
+    );
+    assert.strictEqual(client.keyManagementServiceStub, undefined);
+    await client.initialize();
+    assert(client.keyManagementServiceStub);
+  });
+  it('has close method', () => {
+    const client = new keymanagementserviceModule.v1.KeyManagementServiceClient(
+      {
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      }
+    );
+    client.close();
+  });
   describe('getKeyRing', () => {
     it('invokes getKeyRing without error', done => {
       const client = new keymanagementserviceModule.v1.KeyManagementServiceClient(
@@ -93,6 +113,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IGetKeyRingRequest = {};
       request.name = '';
@@ -118,6 +140,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IGetKeyRingRequest = {};
       request.name = '';
@@ -145,6 +169,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IGetCryptoKeyRequest = {};
       request.name = '';
@@ -170,6 +196,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IGetCryptoKeyRequest = {};
       request.name = '';
@@ -197,6 +225,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IGetCryptoKeyVersionRequest = {};
       request.name = '';
@@ -222,6 +252,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IGetCryptoKeyVersionRequest = {};
       request.name = '';
@@ -249,6 +281,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IGetPublicKeyRequest = {};
       request.name = '';
@@ -274,6 +308,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IGetPublicKeyRequest = {};
       request.name = '';
@@ -301,6 +337,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IGetImportJobRequest = {};
       request.name = '';
@@ -326,6 +364,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IGetImportJobRequest = {};
       request.name = '';
@@ -353,6 +393,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.ICreateKeyRingRequest = {};
       request.parent = '';
@@ -378,6 +420,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.ICreateKeyRingRequest = {};
       request.parent = '';
@@ -405,6 +449,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.ICreateCryptoKeyRequest = {};
       request.parent = '';
@@ -430,6 +476,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.ICreateCryptoKeyRequest = {};
       request.parent = '';
@@ -457,6 +505,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest = {};
       request.parent = '';
@@ -482,6 +532,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.ICreateCryptoKeyVersionRequest = {};
       request.parent = '';
@@ -509,6 +561,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IImportCryptoKeyVersionRequest = {};
       request.parent = '';
@@ -534,6 +588,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IImportCryptoKeyVersionRequest = {};
       request.parent = '';
@@ -561,6 +617,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.ICreateImportJobRequest = {};
       request.parent = '';
@@ -586,6 +644,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.ICreateImportJobRequest = {};
       request.parent = '';
@@ -613,6 +673,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IUpdateCryptoKeyRequest = {};
       request.cryptoKey = {};
@@ -639,6 +701,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IUpdateCryptoKeyRequest = {};
       request.cryptoKey = {};
@@ -667,6 +731,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest = {};
       request.cryptoKeyVersion = {};
@@ -693,6 +759,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IUpdateCryptoKeyVersionRequest = {};
       request.cryptoKeyVersion = {};
@@ -721,6 +789,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IEncryptRequest = {};
       request.name = '';
@@ -746,6 +816,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IEncryptRequest = {};
       request.name = '';
@@ -773,6 +845,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IDecryptRequest = {};
       request.name = '';
@@ -798,6 +872,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IDecryptRequest = {};
       request.name = '';
@@ -825,6 +901,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IAsymmetricSignRequest = {};
       request.name = '';
@@ -850,6 +928,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IAsymmetricSignRequest = {};
       request.name = '';
@@ -877,6 +957,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IAsymmetricDecryptRequest = {};
       request.name = '';
@@ -902,6 +984,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IAsymmetricDecryptRequest = {};
       request.name = '';
@@ -929,6 +1013,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest = {};
       request.name = '';
@@ -954,6 +1040,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IUpdateCryptoKeyPrimaryVersionRequest = {};
       request.name = '';
@@ -984,6 +1072,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest = {};
       request.name = '';
@@ -1009,6 +1099,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IDestroyCryptoKeyVersionRequest = {};
       request.name = '';
@@ -1039,6 +1131,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest = {};
       request.name = '';
@@ -1064,6 +1158,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IRestoreCryptoKeyVersionRequest = {};
       request.name = '';
@@ -1094,6 +1190,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IListKeyRingsRequest = {};
       request.parent = '';
@@ -1123,6 +1221,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IListKeyRingsRequest = {};
       request.parent = '';
@@ -1157,6 +1257,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest = {};
       request.parent = '';
@@ -1186,6 +1288,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IListCryptoKeysRequest = {};
       request.parent = '';
@@ -1220,6 +1324,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest = {};
       request.parent = '';
@@ -1249,6 +1355,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IListCryptoKeyVersionsRequest = {};
       request.parent = '';
@@ -1283,6 +1391,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IListImportJobsRequest = {};
       request.parent = '';
@@ -1312,6 +1422,8 @@ describe('v1.KeyManagementServiceClient', () => {
           projectId: 'bogus',
         }
       );
+      // Initialize client before mocking
+      client.initialize();
       // Mock request
       const request: protosTypes.google.cloud.kms.v1.IListImportJobsRequest = {};
       request.parent = '';


### PR DESCRIPTION
This PR includes changes from https://github.com/googleapis/gapic-generator-typescript/pull/317
that will move the asynchronous initialization and authentication from the client constructor
to an `initialize()` method. This method will be automatically called when the first RPC call
is performed.

The client library usage has not changed, there is no need to update any code.

If you want to make sure the client is authenticated _before_ the first RPC call, you can do
```js
await client.initialize();
```
manually before calling any client method.