### PR TITLE
fix: set validation option false

### DIFF
--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,23 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-kms.git",
-        "sha": "50de8d069c95b12e10daed40f1743d710fac7eff"
+        "remote": "git@github.com:googleapis/nodejs-kms.git",
+        "sha": "4f2a201f7e86cd4cdefa0b5f62d43cefd0898afa"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "6dfd72d028a0d0a43764e060f7b15e004385c3a1",
-        "internalRef": "310168181"
+        "sha": "c4e37010d74071851ff24121f522e802231ac86e",
+        "internalRef": "313460921"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "be74d3e532faa47eb59f1a0eaebde0860d1d8ab4"
+        "sha": "470789cee75ce93c41348ad6aa4c49363a80399b"
       }
     }
   ],

--- a/synth.py
+++ b/synth.py
@@ -34,7 +34,9 @@ for version in versions:
         generator_args={
             "grpc-service-config": f"google/cloud/kms/{version}/cloudkms_grpc_service_config.json",
             "package-name": "@google-cloud/kms",
-            "iam-service": "true"
+            "iam-service": "true",
+            # TODO: proto validation check fail now, it should remove or set true after API producer correct proto syntax
+            "validation": "false",
         },
         proto_path=f'/google/cloud/kms/{version}',
         extra_proto_files=['google/cloud/common_resources.proto']


### PR DESCRIPTION
temporarily set `--validation` false to avoid validation check proto syntax

The `--validation` option should be removed or set `true` once the API producer correct the proto syntax
