### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,5 +13,5 @@
   "issue_tracker": "https://issuetracker.google.com/savedsearches/5264932",
   "codeowner_team": "@googleapis/api-kms",
   "api_shortname": "kms",
-  "library_type": ""
+  "library_type": "GAPIC_AUTO"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/kms/latest",
   "api_id": "kms.googleapis.com",
   "distribution_name": "@google-cloud/kms",
-  "release_level": "ga",
+  "release_level": "stable",
   "default_version": "v1",
   "language": "nodejs",
   "name_pretty": "Google Cloud Key Management Service",
@@ -11,5 +11,7 @@
   "requires_billing": true,
   "name": "kms",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/5264932",
-  "codeowner_team": "@googleapis/api-kms"
+  "codeowner_team": "@googleapis/api-kms",
+  "api_shortname": "kms",
+  "library_type": ""
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Google Cloud Key Management Service: Node.js Client](https://github.com/googleapis/nodejs-kms)
 
-[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+
 [![npm version](https://img.shields.io/npm/v/@google-cloud/kms.svg)](https://www.npmjs.org/package/@google-cloud/kms)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-kms/main.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-kms)
 
@@ -163,12 +163,6 @@ _Legacy Node.js versions are supported as a best effort:_
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-
-This library is considered to be **General Availability (GA)**. This means it
-is stable; the code surface will not change in backwards-incompatible ways
-unless absolutely necessary (e.g. because of critical security issues) or with
-an extensive deprecation period. Issues and requests against **GA** libraries
-are addressed with the highest priority.
 
 
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 
 
+This library is considered to be **stable**. The code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **stable** libraries
+are addressed with the highest priority.
+
 
 
 


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 